### PR TITLE
fix: increase Starship command_timeout to suppress node version warning

### DIFF
--- a/shell/starship/starship.toml
+++ b/shell/starship/starship.toml
@@ -1,6 +1,8 @@
 # Starship prompt configuration
 # Docs: https://starship.rs/config/
 
+command_timeout = 1000
+
 format = """
 $directory\
 $git_branch\
@@ -68,6 +70,8 @@ disabled = true
 format = "[$symbol($version )]($style)"
 symbol = "⬡ "
 style = "green bold"
+detect_files = ["package.json", ".nvmrc", ".node-version"]
+detect_folders = ["node_modules"]
 
 [python]
 format = "[$symbol($version )]($style)"


### PR DESCRIPTION
## Summary

- Adds `command_timeout = 1000` globally to `starship.toml`, doubling the default 500ms limit
- Makes the `nodejs` module detection config explicit (`detect_files`, `detect_folders`) for clarity
- Fixes the `[WARN] - (starship::utils): Executing command "/opt/homebrew/bin/node" timed out` warning on every terminal open

## Test plan

- [ ] Open a new terminal — warning should no longer appear
- [ ] Navigate to a Node.js project — `⬡` symbol with version should still render correctly
- [ ] Prompt render time should feel unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; main impact is prompt rendering behavior (slightly longer waits before timing out) and when the Node.js module is shown.
> 
> **Overview**
> Increases Starship’s global `command_timeout` to `1000ms` to avoid Node command timeout warnings during prompt render.
> 
> Makes the `nodejs` module detection criteria explicit via `detect_files` and `detect_folders`, tightening when the Node version segment appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17433aa4f3ee90b5c4db47df9e23914044fe5b8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->